### PR TITLE
Make first Workflow that outputs commands instead of rendering commands, InitWorkflow, add nice test

### DIFF
--- a/.idea/uiDesigner.xml
+++ b/.idea/uiDesigner.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Palette2">
+    <group name="Swing">
+      <item class="com.intellij.uiDesigner.HSpacer" tooltip-text="Horizontal Spacer" icon="/com/intellij/uiDesigner/icons/hspacer.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="1" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="com.intellij.uiDesigner.VSpacer" tooltip-text="Vertical Spacer" icon="/com/intellij/uiDesigner/icons/vspacer.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="1" anchor="0" fill="2" />
+      </item>
+      <item class="javax.swing.JPanel" icon="/com/intellij/uiDesigner/icons/panel.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JScrollPane" icon="/com/intellij/uiDesigner/icons/scrollPane.png" removable="false" auto-create-binding="false" can-attach-label="true">
+        <default-constraints vsize-policy="7" hsize-policy="7" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JButton" icon="/com/intellij/uiDesigner/icons/button.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="0" fill="1" />
+        <initial-values>
+          <property name="text" value="Button" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JRadioButton" icon="/com/intellij/uiDesigner/icons/radioButton.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="RadioButton" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JCheckBox" icon="/com/intellij/uiDesigner/icons/checkBox.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="CheckBox" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JLabel" icon="/com/intellij/uiDesigner/icons/label.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="Label" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JTextField" icon="/com/intellij/uiDesigner/icons/textField.png" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JPasswordField" icon="/com/intellij/uiDesigner/icons/passwordField.png" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JFormattedTextField" icon="/com/intellij/uiDesigner/icons/formattedTextField.png" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextArea" icon="/com/intellij/uiDesigner/icons/textArea.png" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextPane" icon="/com/intellij/uiDesigner/icons/textPane.png" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JEditorPane" icon="/com/intellij/uiDesigner/icons/editorPane.png" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JComboBox" icon="/com/intellij/uiDesigner/icons/comboBox.png" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="2" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JTable" icon="/com/intellij/uiDesigner/icons/table.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JList" icon="/com/intellij/uiDesigner/icons/list.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="2" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTree" icon="/com/intellij/uiDesigner/icons/tree.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTabbedPane" icon="/com/intellij/uiDesigner/icons/tabbedPane.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSplitPane" icon="/com/intellij/uiDesigner/icons/splitPane.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSpinner" icon="/com/intellij/uiDesigner/icons/spinner.png" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSlider" icon="/com/intellij/uiDesigner/icons/slider.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSeparator" icon="/com/intellij/uiDesigner/icons/separator.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JProgressBar" icon="/com/intellij/uiDesigner/icons/progressbar.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JToolBar" icon="/com/intellij/uiDesigner/icons/toolbar.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1">
+          <preferred-size width="-1" height="20" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JToolBar$Separator" icon="/com/intellij/uiDesigner/icons/toolbarSeparator.png" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JScrollBar" icon="/com/intellij/uiDesigner/icons/scrollbar.png" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="0" anchor="0" fill="2" />
+      </item>
+    </group>
+  </component>
+</project>

--- a/src/main/java/com/wclausen/work/base/CommandOutputWorkflowRunner.kt
+++ b/src/main/java/com/wclausen/work/base/CommandOutputWorkflowRunner.kt
@@ -1,0 +1,90 @@
+package com.wclausen.work.base
+
+import com.github.ajalt.clikt.output.TermUi
+import com.github.michaelbull.result.Result
+import com.squareup.workflow.launchWorkflowIn
+import com.wclausen.work.command.base.Command
+import com.wclausen.work.command.base.CommandOutputWorkflow
+import com.wclausen.work.command.base.Output
+import com.wclausen.work.kotlinext.Do
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.channels.BroadcastChannel
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.produceIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import javax.inject.Inject
+
+/**
+ * Class that runs Command workflows that issue commands through the Workflow's OutputT.
+ *
+ * This contrasts with [CommandWorkflowRunner] where running Workflows issue commands through
+ * RenderingT
+ *
+ * The reason for adding this class and changing the way Commands are issued is that it *should*
+ * make it easier to compose workflows if they issue Commands through outputs rather than
+ * renderings. This goes back to the fact that the UI framework for the application (the terminal)
+ * is not declarative, which breaks the normal expectations of the render loop.
+ *
+ */
+@ExperimentalCoroutinesApi
+class CommandOutputWorkflowRunner<in PropsT, StateT>
+@Inject constructor(
+    private val inputs: BroadcastChannel<PropsT>,
+    private val commandWorkflow: CommandOutputWorkflow<PropsT, StateT>
+) {
+
+    @FlowPreview
+    fun run() = runBlocking {
+        val workJob = Job()
+        val result = launchWorkflowIn(
+            CoroutineScope(workJob),
+            commandWorkflow,
+            inputs.asFlow(),
+            null)
+        { session ->
+            val outputs = session.outputs
+                .produceIn(this)
+
+            launch {
+                while (true) {
+                    val output = outputs.receive()
+                    Do exhaustive when (output) {
+                        is Output.InProgress -> handleCommand(output.command)
+                        is Output.Final<*> -> Unit // do nothing, handled later
+                    }
+                }
+            }
+
+            return@launchWorkflowIn async { session.outputs.filter { it is Output.Final<*> }.first() }
+        }
+
+        val done = result.await()
+        workJob.cancelChildren()
+        done
+    }
+
+    private fun handleCommand(rendering: Command) {
+        Do exhaustive when (rendering) {
+            is Command.Prompt -> {
+                val result = TermUi.prompt(rendering.prompt)!!
+                rendering.nextAction(result)
+            }
+            is Command.Echo -> TermUi.echo(rendering.output)
+            is Command.ExecuteCommand ->
+                WrapperCommand(rendering.onResult)
+                    .main(rendering.args)
+            is Command.MultipleCommands ->
+                rendering.commands.forEach {
+                    handleCommand(it)
+                }
+        }
+    }
+}

--- a/src/main/java/com/wclausen/work/command/base/CommandOutputWorkflow.kt
+++ b/src/main/java/com/wclausen/work/command/base/CommandOutputWorkflow.kt
@@ -1,0 +1,26 @@
+package com.wclausen.work.command.base
+
+import com.github.michaelbull.result.Result
+import com.squareup.workflow.StatefulWorkflow
+
+/**
+ * Command that captures the possible types of output from Workflows.
+ *
+ * A Workflow will either emit a [Command] or a final result as outputs. When the output is a
+ * [Command], the [CommandOutputWorkflowRunner] will execute it. When the output is a final result,
+ * it will be handled by the parent workflow and indicates the child has no more work left to do.
+ */
+sealed class Output {
+
+    data class InProgress(val command: Command) : Output()
+
+    data class Final<T>(val result: Result<T, *>) : Output()
+}
+
+/**
+ * For simplifying declarations of CommandOutputWorkflows
+ *
+ * Note, eventually this is intended to replace the CommandWorkflow and once that happens
+ * the name of this typealias will change to CommandWorkflow
+ */
+typealias CommandOutputWorkflow<PropsT, StateT> = StatefulWorkflow<PropsT, StateT, Output, Unit>

--- a/src/main/java/com/wclausen/work/command/base/MainWorkflow.kt
+++ b/src/main/java/com/wclausen/work/command/base/MainWorkflow.kt
@@ -1,0 +1,42 @@
+package com.wclausen.work.command.base
+
+import com.squareup.workflow.RenderContext
+import com.squareup.workflow.Snapshot
+import com.squareup.workflow.action
+import com.wclausen.work.command.init.InitWorkflow
+import com.wclausen.work.kotlinext.Do
+
+class MainWorkflow(private val initWorkflow: InitWorkflow) : CommandOutputWorkflow<Unit, MainWorkflow.State>() {
+    sealed class State {
+        object Uninitialized : State()
+        object RunningCommand : State()
+    }
+
+    override fun initialState(props: Unit, snapshot: Snapshot?): State {
+        return State.Uninitialized
+    }
+
+    override fun render(props: Unit, state: State, context: RenderContext<State, Output>): Unit {
+        Do exhaustive when (state) {
+            State.Uninitialized -> context.renderChild(initWorkflow, Unit) {
+                action {
+                    Do exhaustive when (it) {
+                        is Output.InProgress -> {
+                            setOutput(it)
+                        }
+                        is Output.Final<*> -> {
+                            nextState =
+                                State.RunningCommand
+                        }
+                    }
+                }
+            }
+            State.RunningCommand ->
+                println("Running Command...")
+        }
+    }
+
+    override fun snapshotState(state: State): Snapshot {
+        return Snapshot.EMPTY
+    }
+}

--- a/src/main/java/com/wclausen/work/command/init/InitCommand.kt
+++ b/src/main/java/com/wclausen/work/command/init/InitCommand.kt
@@ -1,6 +1,9 @@
 package com.wclausen.work.command.init
 
 import com.github.ajalt.clikt.core.CliktCommand
+import com.wclausen.work.base.CommandOutputWorkflowRunner
+import com.wclausen.work.command.base.MainWorkflow
+import kotlinx.coroutines.channels.ConflatedBroadcastChannel
 
 /**
  * Command to initialize CLI tool.
@@ -11,6 +14,9 @@ import com.github.ajalt.clikt.core.CliktCommand
  */
 class InitCommand : CliktCommand(name = "init"){
     override fun run() {
-        // TODO: implement init functionality
+        CommandOutputWorkflowRunner(
+            ConflatedBroadcastChannel(Unit),
+            MainWorkflow(InitWorkflow())
+        ).run()
     }
 }

--- a/src/test/java/com/wclausen/work/command/init/InitWorkflowTest.kt
+++ b/src/test/java/com/wclausen/work/command/init/InitWorkflowTest.kt
@@ -1,0 +1,65 @@
+package com.wclausen.work.command.init
+
+import com.github.michaelbull.result.get
+import com.google.common.truth.Truth.assertThat
+import com.squareup.workflow.testing.WorkflowTester
+import com.squareup.workflow.testing.testFromStart
+import com.wclausen.work.command.base.Command
+import com.wclausen.work.command.base.Output
+import com.wclausen.work.config.Config
+import org.junit.Test
+
+class InitWorkflowTest {
+
+    @Test
+    fun `GIVEN no errors WHEN running workflow THEN completes entire flow`() {
+        // Test of entire flow, mostly to show the kinds of tests possible with workflow :)
+        val expected_username = "some_username"
+        val expected_token = "some_token"
+        InitWorkflow().testFromStart {
+            first()
+                .asksForUsername()
+                .whenUsernameProvided(expected_username)
+            then()
+                .asksForToken()
+                .whenTokenProvided(expected_token)
+            then()
+                .emitsConfig()
+                .withDetails(
+                    username = expected_username,
+                    token = expected_token)
+        }
+    }
+}
+
+private fun Config.withDetails(username: String, token : String) {
+    assertThat(jira.jira_email).isEqualTo(username)
+    assertThat(jira.jira_api_token).isEqualTo(token)
+}
+
+private fun Output.emitsConfig(): Config {
+    assertThat(this).isInstanceOf(Output.Final::class.java)
+    return (this as Output.Final<*>).result.get() as Config
+}
+
+private fun Command.Prompt.whenTokenProvided(token: String) = nextAction.invoke(token)
+
+private fun Output.asksForToken(): Command.Prompt {
+    return assertIsPrompt(InitWorkflow.GET_JIRA_API_TOKEN_PROMPT)
+}
+
+private fun <PropsT, OutputT : Any, RenderingT> WorkflowTester<PropsT, OutputT, RenderingT>.first(): OutputT = awaitNextOutput()
+private fun <PropsT, OutputT : Any, RenderingT> WorkflowTester<PropsT, OutputT, RenderingT>.then(): OutputT = awaitNextOutput()
+
+private fun Command.Prompt.whenUsernameProvided(username: String) = nextAction.invoke(username)
+
+private fun Output.asksForUsername(): Command.Prompt {
+    return assertIsPrompt(InitWorkflow.GET_USERNAME_PROMPT)
+}
+
+private fun Output.assertIsPrompt(expectedText: String): Command.Prompt {
+    val output = this as Output.InProgress
+    val prompt = output.command as Command.Prompt
+    assertThat(prompt.prompt).isEqualTo(expectedText)
+    return prompt
+}


### PR DESCRIPTION
@zach-klippenstein suggested using OutputT instead of RenderingT for issuing commands for terminal to execute. This pr is the first step towards doing that more broadly.

Key additions:

- `CommandOutputWorkflowRunner` to run `Workflow` objects that issue commands via outputs
- `Output` class to capture that Workflows will issue `Commands` to terminal when in progress and then a final `Result` type when finished
- `MainWorkflow` this is more experimental and will hopefully eventually be the starting point for all commands to perform things like reading config info prior to execution of actual commands. Still a WIP
- `InitWorkflow` a workflow that issues `Commands` via outputs instead of renderings
- `InitWorkflowTest` shows some nice literate test capabilities via workflow